### PR TITLE
グラフの UI 周りのレイアウト崩れの修正

### DIFF
--- a/src/components/fetchData/PopulationTransition.tsx
+++ b/src/components/fetchData/PopulationTransition.tsx
@@ -40,13 +40,13 @@ const PopulationTransition = (
               response.data.result.data[0].data.forEach(
                 (eachYearData: { year: any; value: any }, _index: number) => {
                   yearData.push(eachYearData.year);
-                  dataList[18 * index + _index] = eachYearData.value;
+                  dataList[18 * index + _index] = eachYearData.value / 10000;
                 }
               );
             } else {
               response.data.result.data[0].data.forEach(
                 (eachYearData: { year: any; value: any }, _index: number) => {
-                  dataList[18 * index + _index] = eachYearData.value;
+                  dataList[18 * index + _index] = eachYearData.value / 10000;
                 }
               );
             }

--- a/src/components/graph/Graph.tsx
+++ b/src/components/graph/Graph.tsx
@@ -61,7 +61,7 @@ const Graph = ({ equipment, dataList }: Props) => {
             }}
           />
           <Tooltip />
-          <Legend />
+          <Legend width={uiSizeForGraph.xAxisLabelWidth} />
           {exitPrefectureNameList.map((exitPrefectureName, index) => {
             return (
               <Line

--- a/src/components/graph/Graph.tsx
+++ b/src/components/graph/Graph.tsx
@@ -54,7 +54,7 @@ const Graph = ({ equipment, dataList }: Props) => {
           />
           <YAxis
             label={{
-              value: "人口数",
+              value: "人口数 (万人)",
               angle: 0,
               offset: -30,
               position: "insideTop",

--- a/src/components/graph/SettingUiSize.tsx
+++ b/src/components/graph/SettingUiSize.tsx
@@ -3,25 +3,54 @@ import React from "react";
 const SettingUiSize = (equipment: string) => {
   let uiSize;
 
-  if (equipment === "mobile") {
-    uiSize = {
-      width: 350,
-      height: 300,
-      marginTop: 50,
-      marginRight: 20,
-      marginLeft: 20,
-      marginBottom: 0,
-    };
-  } else {
-    uiSize = {
-      width: 700,
-      height: 350,
-      marginTop: 100,
-      marginRight: 35,
-      marginLeft: 20,
-      marginBottom: 0,
-    };
+  switch (equipment) {
+    case "mobile":
+      uiSize = {
+        width: 350,
+        height: 300,
+        marginTop: 50,
+        marginRight: 20,
+        marginLeft: 20,
+        marginBottom: 0,
+        xAxisLabelWidth: 295,
+      };
+      break;
+    case "tablet":
+      uiSize = {
+        width: 700,
+        height: 350,
+        marginTop: 100,
+        marginRight: 35,
+        marginLeft: 20,
+        marginBottom: 0,
+        xAxisLabelWidth: 630,
+      };
+      break;
+    case "pc":
+      uiSize = {
+        width: 700,
+        height: 350,
+        marginTop: 100,
+        marginRight: 35,
+        marginLeft: 20,
+        marginBottom: 0,
+        xAxisLabelWidth: 630,
+      };
+      break;
+    default:
+      uiSize = {
+        width: 700,
+        height: 350,
+        marginTop: 100,
+        marginRight: 35,
+        marginLeft: 20,
+        marginBottom: 0,
+        xAxisLabelWidth: 630,
+      };
+      break;
   }
+
+  console.log(uiSize);
   return uiSize;
 };
 

--- a/src/components/graph/SettingUiSize.tsx
+++ b/src/components/graph/SettingUiSize.tsx
@@ -8,8 +8,8 @@ const SettingUiSize = (equipment: string) => {
       width: 350,
       height: 300,
       marginTop: 50,
-      marginRight: 10,
-      marginLeft: 30,
+      marginRight: 20,
+      marginLeft: 20,
       marginBottom: 0,
     };
   } else {
@@ -17,7 +17,7 @@ const SettingUiSize = (equipment: string) => {
       width: 700,
       height: 350,
       marginTop: 100,
-      marginRight: 30,
+      marginRight: 35,
       marginLeft: 20,
       marginBottom: 0,
     };


### PR DESCRIPTION
## 🔨 変更内容
- グラフの UI 周りの調整を行った
- y軸のラベルの修正
- 折れ線グラフの項目表示の調整
- タブレットに対応した UI の設定 (今回は PC と同じにしているが可変とするために設定)

## 📸 スクリーンショット

## ✅ 解決するイシュー
- close #25
- close #26

## 🤝 関連するイシュー
- #25 
- #26
